### PR TITLE
Fix `NameError` when `make_video` is `True`

### DIFF
--- a/clipit.py
+++ b/clipit.py
@@ -811,7 +811,7 @@ def ascend_txt(args):
     if args.make_video:    
         img = np.array(out.mul(255).clamp(0, 255)[0].cpu().detach().numpy().astype(np.uint8))[:,:,:]
         img = np.transpose(img, (1, 2, 0))
-        imageio.imwrite(f'./steps/frame_{i:04d}.png', np.array(img))
+        imageio.imwrite(f'./steps/frame_{cur_iteration:04d}.png', np.array(img))
 
     return result
 


### PR DESCRIPTION
When saving individual frames, use `cur_iteration` instead of `i` to name the file, since `i` doesn't exist.