### PR TITLE
Fix `settings` not defined error when `make_video` is `True`

### DIFF
--- a/clipit.py
+++ b/clipit.py
@@ -938,7 +938,7 @@ def do_run(args):
             pass
 
     if args.make_video:
-        do_video(settings)
+        do_video(args)
 
 def do_video(args):
     global cur_iteration


### PR DESCRIPTION
I had this error when setting `make_video` option to True
```
NameError                                 Traceback (most recent call last)
<ipython-input-35-0dc56a82cf83> in <module>()
----> 1 clipit.do_run(settings)

/content/clipit/clipit.py in do_run(args)
    939 
    940     if args.make_video:
--> 941         do_video(settings)
    942 
    943 def do_video(args):

NameError: name 'settings' is not defined
```

Fixed it by replacing `settings` variable with `args` in line 941.